### PR TITLE
Prevent onOutsideClick from being triggered right after onSelectedClick

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pusher-ui",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "main": "build/pusher-ui.js",
   "module": "src/index.js",
   "author": "Haukur Páll Hallvarðsson <hph@hph.is>",

--- a/src/components/select.js
+++ b/src/components/select.js
@@ -134,7 +134,9 @@ class Select extends Component {
   componentWillUpdate(nextProps) {
     if (!this.props.isOpen && nextProps.isOpen) {
       this.el.focus();
-      window.addEventListener('click', this.onOutsideClick);
+      setTimeout(() => {
+        window.addEventListener('click', this.onOutsideClick);
+      });
     } else if (this.props.isOpen && !nextProps.isOpen) {
       window.removeEventListener('click', this.onOutsideClick);
     }


### PR DESCRIPTION
By using `setTimeout`, the event listener is only added in the next tick of
the event loop. This prevents it from being fired right after the
onSelectedClick handler is fired. This fixes the issue where only clicking on
the text triggers the dropdown.