### PR TITLE
Handle onClickOutside in Dialog

### DIFF
--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -72,7 +72,7 @@ class Dialog extends Component {
     } = this.props;
     return (
       <Portal {...props} withBackdrop isInstant>
-        <Root>
+        <Root data-root>
           <Container className={className}>
             {title && <Heading danger={danger}>{title}</Heading>}
             {children}

--- a/src/components/portal.js
+++ b/src/components/portal.js
@@ -77,8 +77,9 @@ class Portal extends Component {
   }
 
   onClick = event => {
-    // True when clicking on the portal and not on the rendered children.
-    if (event.currentTarget.children[0] === event.target) {
+    // True when clicking on the portal and not on the rendered children,
+    // unless the root of the rendered children has data-root set.
+    if (event.currentTarget.children[0] === event.target || event.target.dataset.root) {
       this.unrenderPortal();
     }
 


### PR DESCRIPTION
This change allows us to set `onClickOutside` to the dismiss callback for dialogs. They are presently ignored due to the click event not being captured properly.